### PR TITLE
Fixed issues #19 and #20 (broken link and missing module image)

### DIFF
--- a/docs/diy/README.md
+++ b/docs/diy/README.md
@@ -44,7 +44,7 @@ No matter which path you choose above, the following links will offer valuable i
 
 [[akai-mpcone-patchbay.md|Akai MPC One/AE Modular Patchbay]]
 
-[[https://easyeda.com/WonkyStuff/ae-blank-project| Base Schematic for your own circuit design, and templates for making your own PCBs/ Front Panels]]
+[[https://easyeda.com/WonkyStuff/ae-blank-project | Base Schematic for your own circuit design, and templates for making your own PCBs/ Front Panels]]
 
 There is also the DIY section of the AE Modular forum:-
 

--- a/docs/modules/grains.md
+++ b/docs/modules/grains.md
@@ -1,5 +1,5 @@
 # GRAINS
-[[img|modules/images/grains.png|100]]
+[[img|modules/images/GRAINS.png|100]]
 
 [[https://www.tangiblewaves.com/store/p86/GRAINS.html | View Product Page]]
 


### PR DESCRIPTION
Fixed issue https://github.com/aemodular/wiki/issues/19 "missing image for GRAINS" 
Fixed issue https://github.com/aemodular/wiki/issues/20 "broken link" 